### PR TITLE
Allow for multiple config calls to LazyElementsModule.forFeature

### DIFF
--- a/projects/elements/src/lib/lazy-elements/lazy-elements.module.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements.module.ts
@@ -75,9 +75,8 @@ export class LazyElementsModule {
     elementConfigsMultiProvider: ElementConfig[][]
   ) {
     if (elementConfigsMultiProvider && elementConfigsMultiProvider.length) {
-      const lastAddedConfigs =
-        elementConfigsMultiProvider[elementConfigsMultiProvider.length - 1];
-      lazyElementsLoaderService.addConfigs(lastAddedConfigs);
+      const configs = [].concat.apply([], elementConfigsMultiProvider);
+      lazyElementsLoaderService.addConfigs(configs);
     }
   }
 }


### PR DESCRIPTION
If you make multiple calls to `LazyElementsModule.forFeature(options),` ... you will only get the last configuration and lose references to other configs.

![angular-extension bug](https://user-images.githubusercontent.com/1250371/65337614-7e2d8300-db96-11e9-8c72-9840e2711129.png)
