### PR TITLE
Add forRoot guard ensuring this is called only once WIP

### DIFF
--- a/projects/elements/src/lib/lazy-elements/lazy-elements.module.spec.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements.module.spec.ts
@@ -1,0 +1,77 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { LazyElementsModule } from './lazy-elements.module';
+import { NgModule } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Router } from '@angular/router';
+
+const config = {
+  elementConfigs: [
+    { tag: 'some-element', url: 'http://elements.com/some-url' },
+    { tag: 'some-element', url: 'http://elements.com/some-url' },
+    {
+      tag: 'some-other-element',
+      url: 'http://elements.com/some-other-url'
+    },
+    {
+      tag: 'some-module-element',
+      url: 'http://elements.com/some-module-url',
+      isModule: true
+    }
+  ]
+};
+
+@NgModule({
+  imports: [LazyElementsModule.forFeature({})]
+})
+class ForFeatureModule {}
+
+@NgModule({
+  imports: [LazyElementsModule.forRoot({})]
+})
+class ForRootModule {}
+
+describe('LazyElementsModule', () => {
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        LazyElementsModule.forRoot(config),
+        RouterTestingModule.withRoutes([
+          {
+            path: 'feature',
+            loadChildren: () => ForFeatureModule
+          },
+          {
+            path: 'root',
+            loadChildren: () => ForRootModule
+          }
+        ])
+      ]
+    });
+    router = TestBed.get(Router);
+    router.initialNavigation();
+  });
+
+  it('For feature can be call twice', fakeAsync(() => {
+    let error;
+    try {
+      router.navigate(['/feature']);
+      tick();
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeUndefined();
+  }));
+
+  it('For root can not be call twice', fakeAsync(() => {
+    let error;
+    try {
+      router.navigate(['/root']);
+      tick();
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeDefined();
+  }));
+});

--- a/projects/elements/src/lib/lazy-elements/lazy-elements.module.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements.module.ts
@@ -24,7 +24,7 @@ import {
 export function createLazyElementRootGuard(options: LazyElementModuleOptions) {
   if (options) {
     throw new TypeError(
-      `LazyElementsModule.forRoot() called twice. Feature modules should use ThemeModule.forFeature() instead.`
+      `LazyElementsModule.forRoot() called twice. Feature modules should use LazyElementsModule.forFeature() instead.`
     );
   }
   return 'guarded';

--- a/projects/elements/src/lib/lazy-elements/lazy-elements.tokens.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements.tokens.ts
@@ -10,3 +10,7 @@ export const LAZY_ELEMENT_CONFIGS = new InjectionToken<ElementConfig[]>(
 export const LAZY_ELEMENT_ROOT_OPTIONS = new InjectionToken<
   LazyElementRootOptions
 >('LAZY_ELEMENT_ROOT_OPTIONS');
+
+export const LAZY_ELEMENT_ROOT_GUARD = new InjectionToken<void>(
+  'LAZY_ELEMENT_ROOT_GUARD'
+);


### PR DESCRIPTION
This PR adds the first workaround described in https://dev.to/angular/guarding-your-angular-modules-lio by @timdeschryver, tackling the problem described in  https://github.com/angular-extensions/elements/issues/20.


⚠️ TODO:
- [x] add tests
