### PR TITLE
lazy-in-for

### DIFF
--- a/projects/elements/src/lib/lazy-elements/lazy-element-dynamic/lazy-element-dynamic.directive.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-element-dynamic/lazy-element-dynamic.directive.ts
@@ -43,7 +43,6 @@ export class LazyElementDynamicDirective implements OnInit {
     }
 
     const host = (this.template as any)._def.element.template.nodes[0].element;
-    host.name = this.tag;
 
     const elementConfig =
       this.elementsLoaderService.getElementConfig(this.tag) ||
@@ -63,6 +62,7 @@ export class LazyElementDynamicDirective implements OnInit {
       .loadElement(this.url, this.tag, this.isModule)
       .then(() => {
         this.vcr.clear();
+        host.name = this.tag;
         this.vcr.createEmbeddedView(this.template);
       })
       .catch(() => {


### PR DESCRIPTION
Workaround to make the dynamic component work correctly in ngFor. Still have to test this out with requests that take longer than others. 