### PR TITLE
feat(element): add support for dynamic module configuration

### DIFF
--- a/projects/elements/src/lib/lazy-elements/lazy-elements.tokens.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements.tokens.ts
@@ -1,7 +1,11 @@
 import { InjectionToken } from '@angular/core';
 
 import { ElementConfig } from './lazy-elements-loader.service';
-import { LazyElementRootOptions } from './lazy-elements.module';
+import {
+  LazyElementModuleOptions,
+  LazyElementModuleRootOptions,
+  LazyElementRootOptions
+} from './lazy-elements.module';
 
 export const LAZY_ELEMENT_CONFIGS = new InjectionToken<ElementConfig[]>(
   'LAZY_ELEMENT_CONFIGS'
@@ -14,3 +18,11 @@ export const LAZY_ELEMENT_ROOT_OPTIONS = new InjectionToken<
 export const LAZY_ELEMENT_ROOT_GUARD = new InjectionToken<void>(
   'LAZY_ELEMENT_ROOT_GUARD'
 );
+
+export const LAZY_ELEMENT_MODULE_OPTIONS = new InjectionToken<
+  LazyElementModuleOptions
+>('LAZY_ELEMENT_MODULE_OPTIONS');
+
+export const LAZY_ELEMENT_MODULE_ROOT_OPTIONS = new InjectionToken<
+  LazyElementModuleRootOptions
+>('LAZY_ELEMENT_MODULE_ROOT_OPTIONS');


### PR DESCRIPTION
This pull request makes it possible to configure LazyElementsModule with dynamic values known only at runtime, while still allowing for AOT compilation. Implements functionality for #28. The API now supports two signatures:
* Current signature with static values:
```ts
const lazyElementOptions: LazyElementModuleRootOptions = {
    elementConfigs: [
        { tag: 'ba-header', url: 'https://example.com/header-component' }
    ]
};

@NgModule({
    imports: [
        LazyElementsModule.forRoot(lazyElementsConfig)
    ]
})
```
* New signature with dynamic factory:

```ts
export function lazyElementOptionsFactory(): LazyElementModuleRootOptions {
    return {
        elementConfigs: [
            { tag: 'ba-header', url: resolveUrl('ba-header') }
        ]
    };
}

@NgModule({
    imports: [
        LazyElementsModule.forRoot(lazyElementsOptionsFactory)
    ]
})
```

Please review and let me know what you think. I'll work on adding documentation later.