### PR TITLE
feat(service): add ability to override the default lazy element registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ speed-measure-plugin.json
 *.launch
 .settings/
 *.sublime-workspace
+*.iml
 
 # IDE - VSCode
 .vscode/*

--- a/projects/elements/src/lib/lazy-elements/lazy-elements-loader.service.spec.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements-loader.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { LazyElementsLoaderService } from './lazy-elements-loader.service';
 import { LazyElementsModule } from './lazy-elements.module';
+import { DefaultLazyElementsStateService } from './lazy-elements-state.service';
 
 describe('LazyElementsLoaderService', () => {
   let service: LazyElementsLoaderService;
@@ -16,6 +17,18 @@ describe('LazyElementsLoaderService', () => {
 
   it('is created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should no throw and use the default storage and options', () => {
+    let lazyLoaderService;
+    expect(() => {
+      lazyLoaderService = new LazyElementsLoaderService(null, null);
+    }).not.toThrow();
+    expect(
+      lazyLoaderService.lazyElementsStateService instanceof
+        DefaultLazyElementsStateService
+    ).toBe(true);
+    expect(lazyLoaderService.options).toEqual({});
   });
 
   it('throws error if used without url', () => {

--- a/projects/elements/src/lib/lazy-elements/lazy-elements-state.service.spec.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements-state.service.spec.ts
@@ -1,0 +1,27 @@
+import { TestBed } from '@angular/core/testing';
+import { DefaultLazyElementsStateService } from './lazy-elements-state.service';
+
+describe('DefaultLazyElementsStateService', () => {
+  let service: DefaultLazyElementsStateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+
+    service = new DefaultLazyElementsStateService();
+  });
+
+  it('is created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('adds a element to registry', () => {
+    const url = 'http://elements.com/some-element';
+    const elementReference = new Promise<void>((resolve, reject) => {
+      const resolveReference = resolve;
+      const rejectReference = reject;
+    });
+    service.setElement(url, elementReference);
+    expect(service.hasElement(url)).toBeTruthy();
+    expect(service.getElement(url)).toBe(elementReference);
+  });
+});

--- a/projects/elements/src/lib/lazy-elements/lazy-elements-state.service.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements-state.service.ts
@@ -1,0 +1,36 @@
+import { InjectionToken } from '@angular/core';
+
+export interface LazyElementsStateService {
+  getElement(url: string): Promise<void>;
+
+  setElement(url: string, promise: Promise<void>): void;
+
+  hasElement(url: string): boolean;
+}
+
+export class DefaultLazyElementsStateService
+  implements LazyElementsStateService {
+  private registry = new Map<string, Promise<void>>();
+
+  constructor() {}
+
+  getElement(url: string): Promise<void> {
+    return this.registry.get(this.stripUrlProtocol(url));
+  }
+
+  setElement(url: string, elementReference: Promise<void>): void {
+    this.registry.set(this.stripUrlProtocol(url), elementReference);
+  }
+
+  hasElement(url: string): boolean {
+    return this.registry.has(this.stripUrlProtocol(url));
+  }
+
+  private stripUrlProtocol(url: string): string {
+    return url.replace(/https?:\/\//, '');
+  }
+}
+
+export const LAZY_ELEMENTS_STATE = new InjectionToken<
+  Map<string, Promise<void>>
+>('LAZY_ELEMENTS_STATE');

--- a/projects/elements/src/public-api.ts
+++ b/projects/elements/src/public-api.ts
@@ -3,3 +3,4 @@
  */
 
 export * from './lib/lazy-elements/lazy-elements.module';
+export * from './lib/lazy-elements/lazy-elements-state.service';


### PR DESCRIPTION
This pull request makes it possible to configure own LazyElementsStateService and override the default lazy element registry. Like discussed in #9.