### PR TITLE
feat(lib): enable overriding of the elements registry, fixes #9

### DIFF
--- a/projects/elements-demo/src/app/features/docs/api/api.component.html
+++ b/projects/elements-demo/src/app/features/docs/api/api.component.html
@@ -468,3 +468,97 @@ isModule: boolean;</pre
     </table>
   </mat-card>
 </section>
+
+<section>
+  <h2>LAZY_ELEMENTS_REGISTRY</h2>
+  <code color="accent">Token</code>
+  <br />
+  <p>
+    A token used to override default lazy elements registry which is used to
+    prevent multiple downloads of the same element Javascript bundle...
+  </p>
+  <mat-card>
+    <table>
+      <thead>
+        <th>Value</th>
+        <th>Description</th>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <pre>
+&#123;
+  provide: LAZY_ELEMENTS_REGISTRY,
+  useClass: YourRegistryImplementation
+}</pre
+            >
+          </td>
+          <td>
+            <p>
+              Overrides default lazy elements registry implementation which can
+              be useful when using library in the multiple apps (or elements) on
+              a single page to prevent multiple downloads of the same element
+              Javascript bundle. The new implementation has to implement
+              <code>LazyElementsRegistry</code>
+            </p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </mat-card>
+</section>
+
+<section>
+  <h2>LazyElementsRegistry</h2>
+  <code color="accent">Interface</code>
+  <br />
+  <p>
+    An interface which has to be implemented by custom lazy elements registry.
+    The default lazy element registry used by the library out of the box is
+    <code>Map&lt;string, Promise&lt;void></code>
+  </p>
+  <mat-card>
+    <table>
+      <thead>
+        <th>Property</th>
+        <th>Description</th>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <pre>get: (url: string) => Promise&lt;void></pre>
+          </td>
+          <td>
+            <p>
+              Retrieve loading state (<code>Promise</code>) of an element bundle
+              identified by the <code>url</code>
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <pre>set: (url: string, notifier: Promise&lt;void>) => void</pre>
+          </td>
+          <td>
+            <p>
+              Store loading state (<code>Promise</code>) of an element bundle
+              identified by the <code>url</code>
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <pre>has: (url: string) => boolean</pre>
+          </td>
+          <td>
+            <p>
+              Check if registry already contains loading state
+              (<code>Promise</code>) of an element bundle identified by the
+              <code>url</code>
+            </p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </mat-card>
+</section>

--- a/projects/elements-demo/src/app/features/docs/faq/faq.component.ts
+++ b/projects/elements-demo/src/app/features/docs/faq/faq.component.ts
@@ -52,5 +52,12 @@ const FAQ = [
       'In the docs, we often use phrase "Angular elements (or any other web component)" but this may sound a bit vague without previous insight into the topic... <br><br>' +
       'The web standard is in fact called "Web Components" and it uses <a href="https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements" target="_blank">Custom Elements API</a> to create and use web components which are <strong>new custom, reusable, encapsulated HTML tags</strong> to use in web pages and web apps.<br><br>' +
       "Angular Elements wraps Angular components using <code>HTMLElement</code> APIs and then uses Custom Elements API, more precisely the <code>customElements.define('some-element', SomeComponentElement)</code> syntax to register it for the use in the web page."
+  },
+  {
+    question:
+      'How to prevent multiple downloads of same elements bundle when used in the multiple apps / elements?',
+    answer: `
+    It is possible to override the <code>LAZY_ELEMENTS_REGISTRY</code> token and provide your own implementation of the registry which should implement <code>LazyElementsRegistry</code> interface. Such an overridden registry then could store the value globally (for example on the <code>window</code>). That way every instance of lazy elements library can work with this shared state and prevent multiple downloads of some element bundle in case it was already loaded by other library instance before.
+    `
   }
 ];

--- a/projects/elements/src/lib/lazy-elements/lazy-elements-loader.service.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements-loader.service.ts
@@ -1,7 +1,11 @@
 import { Injectable, Type, Optional, Inject } from '@angular/core';
 
 import { LazyElementRootOptions } from './lazy-elements.module';
-import { LAZY_ELEMENT_ROOT_OPTIONS } from './lazy-elements.tokens';
+import {
+  LAZY_ELEMENT_ROOT_OPTIONS,
+  LAZY_ELEMENTS_REGISTRY,
+  LazyElementsRegistry
+} from './lazy-elements.tokens';
 
 const LOG_PREFIX = '@angular-extensions/elements';
 
@@ -18,10 +22,10 @@ export interface ElementConfig {
   providedIn: 'root'
 })
 export class LazyElementsLoaderService {
-  registry: Map<string, Promise<void>> = new Map<string, Promise<void>>();
   configs: ElementConfig[] = [];
 
   constructor(
+    @Inject(LAZY_ELEMENTS_REGISTRY) private registry: LazyElementsRegistry,
     @Optional()
     @Inject(LAZY_ELEMENT_ROOT_OPTIONS)
     public options: LazyElementRootOptions

--- a/projects/elements/src/lib/lazy-elements/lazy-elements.module.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements.module.ts
@@ -18,8 +18,12 @@ import {
 import {
   LAZY_ELEMENT_ROOT_OPTIONS,
   LAZY_ELEMENT_CONFIGS,
-  LAZY_ELEMENT_ROOT_GUARD
+  LAZY_ELEMENT_ROOT_GUARD,
+  LAZY_ELEMENTS_REGISTRY,
+  LazyElementsRegistry
 } from './lazy-elements.tokens';
+
+export { LAZY_ELEMENTS_REGISTRY, LazyElementsRegistry };
 
 export function createLazyElementRootGuard(options: LazyElementModuleOptions) {
   if (options) {

--- a/projects/elements/src/lib/lazy-elements/lazy-elements.tokens.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements.tokens.ts
@@ -14,3 +14,17 @@ export const LAZY_ELEMENT_ROOT_OPTIONS = new InjectionToken<
 export const LAZY_ELEMENT_ROOT_GUARD = new InjectionToken<void>(
   'LAZY_ELEMENT_ROOT_GUARD'
 );
+
+export const LAZY_ELEMENTS_REGISTRY = new InjectionToken<LazyElementsRegistry>(
+  'Lazu elements registry',
+  {
+    providedIn: 'root',
+    factory: () => new Map<string, Promise<void>>()
+  }
+);
+
+export interface LazyElementsRegistry {
+  get: (url: string) => Promise<void>;
+  set: (url: string, notifier: Promise<void>) => void;
+  has: (url: string) => boolean;
+}


### PR DESCRIPTION
- use LAZY_ELEMENTS_REGISTRY token (with LazyElementsRegistry interface)
- can be used to share registry between multiple apps / elements
- can prevent multiple downloads of the same javascript bundles