### PR TITLE
Proper error if used without url from config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ speed-measure-plugin.json
 *.launch
 .settings/
 *.sublime-workspace
+*.iml
 
 # IDE - VSCode
 .vscode/*

--- a/projects/elements/src/lib/lazy-elements/lazy-elements-loader.service.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements-loader.service.ts
@@ -73,7 +73,7 @@ export class LazyElementsLoaderService {
     const config = this.getElementConfig(tag);
 
     if (!url) {
-      if (!config) {
+      if (!config || !config.url) {
         throw new Error(`${LOG_PREFIX} - url for <${tag}> not found`);
       }
       url = config.url;


### PR DESCRIPTION
Proper handling of not defined url in config