### PR TITLE
Add hooks support

### DIFF
--- a/projects/elements-demo/src/app/features/docs/api/api.component.html
+++ b/projects/elements-demo/src/app/features/docs/api/api.component.html
@@ -304,6 +304,19 @@ isModule: boolean;</pre
             >
           </td>
         </tr>
+        <tr>
+          <td><pre>hooksConfig: HooksConfig</pre></td>
+          <td>
+            <p>
+              Global hooks configuration for all elements. Any loaded element
+              will run hooks configured here unless some of them were overriden
+              in <code>ElementConfig</code>.
+            </p>
+            <code color="accent">Optional</code>&nbsp;<code color="accent"
+              >Default: undefined</code
+            >
+          </td>
+        </tr>
       </tbody>
     </table>
   </mat-card>
@@ -426,6 +439,99 @@ isModule: boolean;</pre
             <code color="accent">Optional</code>&nbsp;<code color="accent"
               >Default: undefined</code
             >
+          </td>
+        </tr>
+        <tr>
+          <td><pre>hooks: HooksConfig</pre></td>
+          <td>
+            <p>
+              Hooks configuration for the element. Any hook specified here will
+              overwrite corresponding root hook for the element. See
+              <code>HooksConfig</code>.
+            </p>
+            <code color="accent">Optional</code>&nbsp;<code color="accent"
+              >Default: undefined</code
+            >
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </mat-card>
+</section>
+
+<section>
+  <h2>HooksConfig</h2>
+  <code color="accent">Interface</code>
+  <br />
+  <p>
+    Hooks for running custom logic as part of the element's lifecycle. See
+    <code>ElementConfig</code> and <code>LazyElementRootOptions</code>.
+  </p>
+  <mat-card>
+    <table>
+      <thead>
+        <th>Property</th>
+        <th>Description</th>
+      </thead>
+      <tbody>
+        <tr>
+          <td><pre>beforeLoad: Hook</pre></td>
+          <td>
+            <p>
+              This hook will run before the browser starts the element's
+              download. If the provided hook returns a <code>Promise</code> the
+              element's download will be postponed until the Promise is
+              resolved.
+            </p>
+            <code color="accent">Optional</code>&nbsp;<code color="accent"
+              >Default: undefined</code
+            >
+          </td>
+        </tr>
+        <tr>
+          <td><pre>afterLoad: Hook</pre></td>
+          <td>
+            <p>
+              This hook will run after the element's download has been
+              completed. If the provided hook returns a <code>Promise</code> the
+              element's insertion into the corresponding Angular's view will be
+              postponed until the Promise is resolved.
+            </p>
+            <code color="accent">Optional</code>&nbsp;<code color="accent"
+              >Default: undefined</code
+            >
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </mat-card>
+</section>
+
+<section>
+  <h2>Hook</h2>
+  <code color="accent">Type</code>
+  <br />
+  <p>Hook that can be run as part of <code>HooksConfig</code>.</p>
+  <mat-card>
+    <table>
+      <thead>
+        <th>Value</th>
+        <th>Description</th>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <pre>
+(tag: string) => Promise&lt;void&gt; &#x2758; &lt;void&gt;</pre
+            >
+          </td>
+          <td>
+            <p>
+              Provided function will be called at the appropriate time in the
+              element's lifecycle. If the function returns a
+              <code>Promise</code> the library will wait for its' resolution
+              before proceeding.
+            </p>
           </td>
         </tr>
       </tbody>

--- a/projects/elements-demo/src/app/features/examples/advanced/advanced.component.html
+++ b/projects/elements-demo/src/app/features/examples/advanced/advanced.component.html
@@ -173,4 +173,30 @@
       <pre [highlight]="codeExample5ts"></pre>
     </div>
   </div>
+
+  <h2 id="hooks">
+    Hooks
+  </h2>
+  <div class="content">
+    <div class="implementation" *ngIf="!example6">
+      <button mat-flat-button color="accent" (click)="example6 = true">
+        <mat-icon>play_arrow</mat-icon>
+        Run
+      </button>
+    </div>
+    <div class="implementation" *ngIf="example6">
+      <mwc-slider *axLazyElement></mwc-slider>
+    </div>
+    <div class="description">
+      <p>
+        By providing hooks in <code>ElementConfig</code> or
+        <code>LazyElementRootOptions</code>
+        you can run custom logic after certain points in the element's
+        lifecycle. Clicking the run button below will trigger the download of
+        the custom element which has been configured with a hook.
+      </p>
+      <pre [highlight]="codeExample6html"></pre>
+      <pre [highlight]="codeExample6module"></pre>
+    </div>
+  </div>
 </div>

--- a/projects/elements-demo/src/app/features/examples/advanced/advanced.component.ts
+++ b/projects/elements-demo/src/app/features/examples/advanced/advanced.component.ts
@@ -12,6 +12,7 @@ export class AdvancedComponent implements OnInit {
   example2 = false;
   example3 = false;
   example4 = false;
+  example6 = false;
 
   // example code examples
   codeExample1module = CODE_EXAMPLE_1_MODULE;
@@ -24,6 +25,8 @@ export class AdvancedComponent implements OnInit {
   codeExample4coreModule = CODE_EXAMPLE_4_CORE_MODULE;
   codeExample5html = CODE_EXAMPLE_5_HTML;
   codeExample5ts = CODE_EXAMPLE_5_TS;
+  codeExample6html = CODE_EXAMPLE_6_HTML;
+  codeExample6module = CODE_EXAMPLE_6_MODULE;
 
   // example state
   counter = 0;
@@ -160,3 +163,36 @@ class PageComponent {
   }
 }
 `;
+
+const CODE_EXAMPLE_6_MODULE = `// pre-configured LazyElementsModule
+export function beforeLoadHook(tag: string): Promise<void> {
+  alert(\`Starting download of \${tag} web component! The download will be artificially postponed for 5 seconds.\`);
+  return new Promise(res => setTimeout(res, 5000));
+}
+
+const options: LazyElementModuleOptions = {
+  elementConfigs: [
+    {
+      tag: 'mwc-slider',
+      url: 'https://unpkg.com/@material/mwc-slider@0.14.1/mwc-slider.js?module',
+      isModule: true,
+      hooks: {
+        beforeLoad: beforeLoadHook
+      }
+      loadingComponent: SpinnerComponent,
+      errorComponent: ErrorComponent
+    }
+  ]
+};
+
+@NgModule({
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  declarations: [FeatureComponent],
+  imports: [
+    LazyElementsModule.forFeature(options),
+  ]
+})
+export class FeatureModule { }
+`;
+
+const CODE_EXAMPLE_6_HTML = `<mwc-slider *axLazyElement></mwc-slider>`;

--- a/projects/elements-demo/src/app/features/examples/advanced/advanced.module.ts
+++ b/projects/elements-demo/src/app/features/examples/advanced/advanced.module.ts
@@ -13,6 +13,13 @@ import { AdvancedComponent } from './advanced.component';
 import { SpinnerComponent } from '../../../shared/spinner/spinner.component';
 import { ErrorComponent } from '../../../shared/error/error.component';
 
+export function beforeLoadHook(tag: string): Promise<void> {
+  alert(
+    `Starting download of ${tag} web component! The download will be artificially postponed for 5 seconds.`
+  );
+  return new Promise(res => setTimeout(res, 5000));
+}
+
 const options: LazyElementModuleOptions = {
   elementConfigs: [
     {
@@ -39,6 +46,14 @@ const options: LazyElementModuleOptions = {
       url: 'https://unpkg.com/@material/mwc-fab@0.6.0/mwc-fab.js?module',
       isModule: true,
       loadingComponent: SpinnerComponent
+    },
+    {
+      tag: 'mwc-slider',
+      url: 'https://unpkg.com/@material/mwc-slider@0.14.1/mwc-slider.js?module',
+      isModule: true,
+      hooks: {
+        beforeLoad: beforeLoadHook
+      }
     }
   ]
 };

--- a/projects/elements/src/lib/lazy-elements/lazy-element-dynamic/lazy-element-dynamic.directive.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-element-dynamic/lazy-element-dynamic.directive.ts
@@ -65,7 +65,7 @@ export class LazyElementDynamicDirective implements OnInit {
     }
 
     this.elementsLoaderService
-      .loadElement(this.url, this.tag, this.isModule)
+      .loadElement(this.url, this.tag, this.isModule, elementConfig?.hooks)
       .then(() => {
         this.vcr.clear();
         const originalCreateElement = this.renderer.createElement;

--- a/projects/elements/src/lib/lazy-elements/lazy-element/lazy-element.directive.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-element/lazy-element.directive.ts
@@ -52,7 +52,7 @@ export class LazyElementDirective implements OnInit {
       this.vcr.createComponent(factory);
     }
     this.elementsLoaderService
-      .loadElement(this.url, elementTag, this.isModule)
+      .loadElement(this.url, elementTag, this.isModule, elementConfig?.hooks)
       .then(() => {
         this.vcr.clear();
         this.vcr.createEmbeddedView(this.template);

--- a/projects/elements/src/lib/lazy-elements/lazy-elements-loader.service.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements-loader.service.ts
@@ -113,13 +113,17 @@ export class LazyElementsLoaderService {
     if (!this.hasElement(url)) {
       const notifier = this.addElement(url);
       const script = document.createElement('script') as HTMLScriptElement;
+      const beforeLoadHook =
+        hooksConfig?.beforeLoad ?? this.options?.hooks?.beforeLoad;
+      const afterLoadHook =
+        hooksConfig?.afterLoad ?? this.options?.hooks?.afterLoad;
       if (isModule) {
         script.type = 'module';
       }
       script.src = url;
       script.onload = () => {
-        if (hooksConfig?.afterLoad) {
-          this.handleHook(hooksConfig.afterLoad, tag)
+        if (afterLoadHook) {
+          this.handleHook(afterLoadHook, tag)
             .then(notifier.resolve)
             .catch(notifier.reject);
         } else {
@@ -127,8 +131,8 @@ export class LazyElementsLoaderService {
         }
       };
       script.onerror = notifier.reject;
-      if (hooksConfig?.beforeLoad) {
-        this.handleHook(hooksConfig.beforeLoad, tag)
+      if (beforeLoadHook) {
+        this.handleHook(beforeLoadHook, tag)
           .then(() => document.body.appendChild(script))
           .catch(notifier.reject);
       } else {

--- a/projects/elements/src/lib/lazy-elements/lazy-elements-loader.service.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements-loader.service.ts
@@ -114,9 +114,13 @@ export class LazyElementsLoaderService {
       const notifier = this.addElement(url);
       const script = document.createElement('script') as HTMLScriptElement;
       const beforeLoadHook =
-        hooksConfig?.beforeLoad ?? this.options?.hooks?.beforeLoad;
+        hooksConfig?.beforeLoad ??
+        config?.hooks?.beforeLoad ??
+        this.options?.hooks?.beforeLoad;
       const afterLoadHook =
-        hooksConfig?.afterLoad ?? this.options?.hooks?.afterLoad;
+        hooksConfig?.afterLoad ??
+        config?.hooks?.afterLoad ??
+        this.options?.hooks?.afterLoad;
       if (isModule) {
         script.type = 'module';
       }
@@ -161,7 +165,7 @@ export class LazyElementsLoaderService {
   }
 
   private isPromise<T>(obj: T | Promise<T>): obj is Promise<T> {
-    return typeof (obj as any).then === 'function';
+    return typeof (obj as any)?.then === 'function';
   }
 
   private handleHook(hook: Hook, tag: string): Promise<void> {

--- a/projects/elements/src/lib/lazy-elements/lazy-elements.module.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements.module.ts
@@ -12,7 +12,8 @@ import { LazyElementDirective } from './lazy-element/lazy-element.directive';
 import { LazyElementDynamicDirective } from './lazy-element-dynamic/lazy-element-dynamic.directive';
 import {
   ElementConfig,
-  LazyElementsLoaderService
+  LazyElementsLoaderService,
+  HooksConfig
 } from './lazy-elements-loader.service';
 import {
   LAZY_ELEMENT_ROOT_OPTIONS,
@@ -108,4 +109,5 @@ export interface LazyElementRootOptions {
   errorComponent?: Type<any>;
   isModule?: boolean;
   preload?: boolean;
+  hooks?: HooksConfig;
 }


### PR DESCRIPTION
Add `beforeLoad` and `afterLoad` hooks to `ElementConfig`. This closes #46 

@tomastrajan please take a look at the implementation. If everything is good, I will add unit tests to this PR.