### PR TITLE
fix(elements): fix binding issue

### DIFF
--- a/projects/elements/src/lib/lazy-elements/lazy-element-dynamic/lazy-element-dynamic.directive.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-element-dynamic/lazy-element-dynamic.directive.ts
@@ -66,6 +66,7 @@ export class LazyElementDynamicDirective implements OnInit {
 
     this.elementsLoaderService
       .loadElement(this.url, this.tag, this.isModule, elementConfig?.hooks)
+      .then(() => customElements.whenDefined(this.tag))
       .then(() => {
         this.vcr.clear();
         const originalCreateElement = this.renderer.createElement;

--- a/projects/elements/src/lib/lazy-elements/lazy-element/lazy-element.directive.spec.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-element/lazy-element.directive.spec.ts
@@ -80,6 +80,7 @@ describe('LazyElementDirective', () => {
   let testHostComponent: TestHostComponent;
   let fixture: ComponentFixture<TestHostComponent>;
   let appendChildSpy: jasmine.Spy;
+  let whenDefinedSpy: jasmine.Spy;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -104,6 +105,9 @@ describe('LazyElementDirective', () => {
     fixture = TestBed.createComponent(TestHostComponent);
     testHostComponent = fixture.componentInstance;
     appendChildSpy = spyOn(document.body, 'appendChild').and.stub();
+    whenDefinedSpy = spyOn(customElements, 'whenDefined').and.returnValue(
+      Promise.resolve()
+    );
     fixture.detectChanges();
   });
 

--- a/projects/elements/src/lib/lazy-elements/lazy-element/lazy-element.directive.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-element/lazy-element.directive.ts
@@ -53,6 +53,7 @@ export class LazyElementDirective implements OnInit {
     }
     this.elementsLoaderService
       .loadElement(this.url, elementTag, this.isModule, elementConfig?.hooks)
+      .then(() => customElements.whenDefined(elementTag))
       .then(() => {
         this.vcr.clear();
         this.vcr.createEmbeddedView(this.template);


### PR DESCRIPTION
Fix binding issue when using element in a parent Angular application.
Looks like binding issue occurred due to a race condition between browser parsing and executing the script and Angular trying to create the view from the template. If the script is big enough Angular finishes first and the bindings are set incorrectly.
This fixed version waits for the custom element to be defined in the global registry before handling the control to Angular.
Closes #50 