### PR TITLE
feat(lib): public method to destroy embedded view

### DIFF
--- a/projects/elements-demo/src/app/features/docs/api/api.component.html
+++ b/projects/elements-demo/src/app/features/docs/api/api.component.html
@@ -137,6 +137,28 @@ isModule: boolean;</pre
       </tbody>
     </table>
   </mat-card>
+  <mat-card>
+    <table>
+      <thead>
+        <th>Function</th>
+        <th>Description</th>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <pre>destroyEmbeddedView()</pre>
+          </td>
+          <td>
+            <p>
+              The <code>destroyEmbeddedView</code>
+              is a public method which can be called by parent component to
+              destroy element's embedded view on demand.
+            </p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </mat-card>
 </section>
 
 <section>

--- a/projects/elements/src/lib/lazy-elements/lazy-element-dynamic/lazy-element-dynamic.directive.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-element-dynamic/lazy-element-dynamic.directive.ts
@@ -7,7 +7,8 @@ import {
   ComponentFactoryResolver,
   ChangeDetectorRef,
   Renderer2,
-  Inject
+  Inject,
+  EmbeddedViewRef
 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 
@@ -32,6 +33,8 @@ export class LazyElementDynamicDirective implements OnInit {
     any
   >; // tslint:disable-line:no-input-rename
   @Input('axLazyElementDynamicModule') isModule: boolean | undefined; // tslint:disable-line:no-input-rename
+
+  private viewRef: EmbeddedViewRef<any> = null;
 
   constructor(
     @Inject(DOCUMENT) private document: Document,
@@ -75,7 +78,7 @@ export class LazyElementDynamicDirective implements OnInit {
           }
           return this.document.createElement(name);
         };
-        this.vcr.createEmbeddedView(this.template);
+        this.viewRef = this.vcr.createEmbeddedView(this.template);
         this.renderer.createElement = originalCreateElement;
         this.cdr.markForCheck();
       })
@@ -97,5 +100,13 @@ export class LazyElementDynamicDirective implements OnInit {
           );
         }
       });
+  }
+
+  destroyEmbeddedView() {
+    if (this.viewRef && !this.viewRef.destroyed) {
+      this.viewRef.detach();
+      this.viewRef.destroy();
+      this.viewRef = null;
+    }
   }
 }

--- a/projects/elements/src/lib/lazy-elements/lazy-element/lazy-element.directive.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-element/lazy-element.directive.ts
@@ -5,7 +5,8 @@ import {
   TemplateRef,
   ViewContainerRef,
   ComponentFactoryResolver,
-  ChangeDetectorRef
+  ChangeDetectorRef,
+  EmbeddedViewRef
 } from '@angular/core';
 
 import {
@@ -23,6 +24,8 @@ export class LazyElementDirective implements OnInit {
   @Input('axLazyElementLoadingTemplate') loadingTemplateRef: TemplateRef<any>; // tslint:disable-line:no-input-rename
   @Input('axLazyElementErrorTemplate') errorTemplateRef: TemplateRef<any>; // tslint:disable-line:no-input-rename
   @Input('axLazyElementModule') isModule: boolean | undefined; // tslint:disable-line:no-input-rename
+
+  private viewRef: EmbeddedViewRef<any> = null;
 
   constructor(
     private vcr: ViewContainerRef,
@@ -55,7 +58,7 @@ export class LazyElementDirective implements OnInit {
       .loadElement(this.url, elementTag, this.isModule, elementConfig?.hooks)
       .then(() => {
         this.vcr.clear();
-        this.vcr.createEmbeddedView(this.template);
+        this.viewRef = this.vcr.createEmbeddedView(this.template);
         this.cdr.markForCheck();
       })
       .catch(() => {
@@ -75,5 +78,13 @@ export class LazyElementDirective implements OnInit {
           );
         }
       });
+  }
+
+  destroyEmbeddedView() {
+    if (this.viewRef && !this.viewRef.destroyed) {
+      this.viewRef.detach();
+      this.viewRef.destroy();
+      this.viewRef = null;
+    }
   }
 }


### PR DESCRIPTION
Need a way to destroy embedded view on demand. 
Calling it before redirecting can help handling any errors (ex: destroyView error) to allow router navigation complete successfully.   
Example of the error when loading element in the template (similar to LazyElementDynamic directive): 
https://github.com/angular/angular/issues/29606  