### PR TITLE
feat: pass script loading error to the `ErrorHandler`

### DIFF
--- a/projects/elements/src/lib/lazy-elements/lazy-element/lazy-element.directive.spec.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-element/lazy-element.directive.spec.ts
@@ -196,7 +196,6 @@ describe('LazyElementDirective', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       '@angular-extensions/elements - Loading of element <some-element> failed, please provide <ng-template #error>Loading failed...</ng-template> and reference it in *axLazyElement="errorTemplate: error" to display customized error message in place of element'
     );

--- a/projects/elements/src/lib/lazy-elements/lazy-elements-loader.service.spec.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements-loader.service.spec.ts
@@ -1,3 +1,4 @@
+import { ErrorHandler } from '@angular/core';
 import { TestBed, waitForAsync } from '@angular/core/testing';
 
 import {
@@ -376,6 +377,26 @@ describe('LazyElementsLoaderService preconfigured with LazyElementsModule', () =
           expect(resolveSpy).toHaveBeenCalledWith('element');
           done();
         });
+    });
+  });
+
+  describe('ErrorHandler', () => {
+    it('should be possible to handle the error thrown during the script loading', (done) => {
+      shouldLoadSucceed = false;
+
+      const errorHandler = TestBed.inject(ErrorHandler);
+      const handleErrorSpy = spyOn(errorHandler, 'handleError');
+
+      const promise = service.loadElement(
+        'http://elements.com/some-element',
+        'some-element'
+      );
+
+      promise
+        .catch(() => {
+          expect(handleErrorSpy).toHaveBeenCalledTimes(1);
+        })
+        .finally(done);
     });
   });
 });

--- a/projects/elements/src/lib/lazy-elements/lazy-elements-loader.service.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-elements-loader.service.ts
@@ -1,4 +1,10 @@
-import { Inject, Injectable, Optional, Type } from '@angular/core';
+import {
+  ErrorHandler,
+  Inject,
+  Injectable,
+  Optional,
+  Type,
+} from '@angular/core';
 
 import { LazyElementRootOptions } from './lazy-elements.module';
 import {
@@ -35,6 +41,7 @@ export class LazyElementsLoaderService {
   configs: ElementConfig[] = [];
 
   constructor(
+    private errorHandler: ErrorHandler,
     @Inject(LAZY_ELEMENTS_REGISTRY) private registry: LazyElementsRegistry,
     @Optional()
     @Inject(LAZY_ELEMENT_ROOT_OPTIONS)
@@ -155,6 +162,10 @@ export class LazyElementsLoaderService {
       const onError = (error: ErrorEvent) => {
         notifier.reject(error);
         cleanup();
+        // Caretaker note: don't put it before the `reject` and `cleanup` since the user may have some
+        // custom error handler that will re-throw the error through `throw error`. Hence the code won't
+        // be executed, and the promise won't be rejected.
+        this.errorHandler.handleError(error);
       };
       // The `load` and `error` event listeners capture `this`. That's why they have to be removed manually.
       // Otherwise, the `LazyElementsLoaderService` is not going to be GC'd.


### PR DESCRIPTION
Hey! Just added `ErrorHandler.handleError` call into the `script.onerror` inside the service.

This should close that issue https://github.com/angular-extensions/elements/issues/81