### PR TITLE
Fix issue with the isModule property being ignored.

### DIFF
--- a/projects/elements/src/lib/lazy-elements/lazy-element/lazy-element.directive.spec.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-element/lazy-element.directive.spec.ts
@@ -60,6 +60,9 @@ class TestModule {}
       <some-element
         *axLazyElement="'http://elements.com/some-element-module'; module: true"
       ></some-element>
+      <some-configured-module-element
+        *axLazyElement
+      ></some-configured-module-element>
     </div>
     <div *ngIf="useImportMap">
       <some-element
@@ -93,6 +96,10 @@ describe('LazyElementDirective', () => {
   let appendChildSpy: jest.SpyInstance;
   let whenDefinedSpy: jest.SpyInstance;
 
+  function appendedScriptElements(): HTMLScriptElement[] {
+    return appendChildSpy.mock.calls.map((args) => args[0]);
+  }
+
   function getAppendChildFirstScript(): HTMLScriptElement {
     return appendChildSpy.mock.calls[0][0];
   }
@@ -111,6 +118,12 @@ describe('LazyElementDirective', () => {
               tag: 'some-configured-element',
               url: 'http://elements.com/some-configured-element-module',
               loadingComponent: SpinnerTestComponent,
+            },
+            {
+              tag: 'some-configured-module-element',
+              url: 'http://elements.com/some-configured-element-module',
+              loadingComponent: SpinnerTestComponent,
+              isModule: true,
             },
           ],
         }),
@@ -241,11 +254,12 @@ describe('LazyElementDirective', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(appendChildSpy).toHaveBeenCalledTimes(2);
-    expect(getAppendChildSecondScript().src).toBe(
-      'http://elements.com/some-element-module'
-    );
-    expect(getAppendChildSecondScript().type).toBe('module');
+    expect(appendChildSpy).toHaveBeenCalledTimes(3);
+    expect(appendedScriptElements().map((script) => script.type)).toEqual([
+      '',
+      'module',
+      'module',
+    ]);
   });
 
   it('uses import map when specified', async () => {

--- a/projects/elements/src/lib/lazy-elements/lazy-element/lazy-element.directive.ts
+++ b/projects/elements/src/lib/lazy-elements/lazy-element/lazy-element.directive.ts
@@ -42,7 +42,7 @@ export class LazyElementDirective implements OnChanges, OnInit, OnDestroy {
   loadingTemplateRef: TemplateRef<any> | null = null;
   @Input('axLazyElementErrorTemplate') // eslint-disable-line @angular-eslint/no-input-rename
   errorTemplateRef: TemplateRef<any> | null = null;
-  @Input('axLazyElementModule') isModule = false; // eslint-disable-line @angular-eslint/no-input-rename
+  @Input('axLazyElementModule') isModule?: boolean; // eslint-disable-line @angular-eslint/no-input-rename
   @Input('axLazyElementImportMap') importMap = false; // eslint-disable-line @angular-eslint/no-input-rename
 
   private viewRef: EmbeddedViewRef<any> | null = null;


### PR DESCRIPTION
Fixes #123 

There might be more similar cases introduced when the `strict` mode was being enabled in `tsconfig.json`. 
I am not aware of them as I am mostly configuring elements using `ElementConfig`s.