### PR TITLE
docs: update import in testing docs

### DIFF
--- a/projects/elements-demo/src/app/features/examples/testing/testing.component.ts
+++ b/projects/elements-demo/src/app/features/examples/testing/testing.component.ts
@@ -48,11 +48,11 @@ describe('FeatureComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [FeatureComponent, MockElementComponent],
+            imports: [FeatureComponent],
         })
         .overrideComponent(FeatureComponent, {
           remove: { imports: [ LazyElementDirective ] },
-          add: { imports: [ LazyElementTestingDirective ] }
+          add: { imports: [ LazyElementTestingDirective, MockElementComponent ] }
         })
         .compileComponents();
     });


### PR DESCRIPTION
This PR updates the "Testing" documentation. For me, it only started working after I added the mocked component to the `overrideComponent.add` list.